### PR TITLE
Clean-up jobs

### DIFF
--- a/src/initializers/redis.ts
+++ b/src/initializers/redis.ts
@@ -5,11 +5,7 @@ const redisOptions: Redis.RedisOptions = {
   enableReadyCheck: false,
 };
 
-const connection = new Redis(
+export default new Redis(
   process.env.REDIS_URL || 'redis://127.0.0.1:6379',
   redisOptions,
 );
-
-export default {
-  connection,
-};

--- a/src/jobs/collectPerformance.ts
+++ b/src/jobs/collectPerformance.ts
@@ -3,7 +3,7 @@ import { vaultPerformance } from '../contracts/vault';
 import { createJob } from './helpers';
 
 const JOB_NAME = 'collectPerformance';
-const INTERVAL = 24;
+const INTERVAL = 1;
 
 export default createJob(JOB_NAME, INTERVAL, async function () {
   const repository = await getVaultMetricRepository();

--- a/src/worker/scheduler/index.ts
+++ b/src/worker/scheduler/index.ts
@@ -17,7 +17,7 @@ const scheduler = new QueueScheduler(SCHEDULER_QUEUE, {
 const schedulerQueue = new Queue(SCHEDULER_QUEUE, {
   connection: redisConnection,
   defaultJobOptions: {
-    attempts: 2,
+    attempts: 3,
     backoff: {
       type: 'exponential',
       delay: 1000,


### PR DESCRIPTION
* updated `initializers/redis.ts` because it returned an object that was coupled to the format expected by bullmq.
* changed the collect performance interval to 1 hour. We can always ignore data, but having it is better than not having it.
* the jobs don't need ids because the names are already unique.
* added a small retry with exponential backoff because sometimes things fail for weird reasons, and might as well give it another go instead of waiting for the job to run again.