### PR TITLE
Handle TheGivingBlock API change

### DIFF
--- a/src/organizations/index.ts
+++ b/src/organizations/index.ts
@@ -112,7 +112,7 @@ async function updateOrganizationDetails(organization: Organization) {
 async function getOrganizationById(id: number) {
   const response = await axios.get(`${BASE_URL}/v1/organization/${id}`, {
     headers: { Authorization: `Bearer ${accessToken}` },
-    validateStatus: status => status <= 400,
+    validateStatus: (status) => status <= 400,
   });
 
   if (response.status == 400) return {};
@@ -128,7 +128,7 @@ async function getOrganizationById(id: number) {
 }
 
 function updateCachedOrganizations(organizations: Organization[]) {
-  const detailedOrganizations = organizations.filter(org => org.categories);
+  const detailedOrganizations = organizations.filter((org) => org.categories);
 
   cachedOrganizations = cachedOrganizations
     .filter(({ id }) => !_.find(organizations, { id }))

--- a/src/organizations/index.ts
+++ b/src/organizations/index.ts
@@ -1,5 +1,5 @@
 import async from 'async';
-import axios from 'axios';
+import axios, { Axios } from 'axios';
 import _ from 'lodash';
 import logger from '../logger';
 
@@ -112,7 +112,10 @@ async function updateOrganizationDetails(organization: Organization) {
 async function getOrganizationById(id: number) {
   const response = await axios.get(`${BASE_URL}/v1/organization/${id}`, {
     headers: { Authorization: `Bearer ${accessToken}` },
+    validateStatus: status => status <= 400,
   });
+
+  if (response.status == 400) return {};
 
   const data: { organization?: Organization } = response.data.data;
 
@@ -124,9 +127,11 @@ async function getOrganizationById(id: number) {
   return data.organization;
 }
 
-function updateCachedOrganizations(detailedOrganizations: Organization[]) {
+function updateCachedOrganizations(organizations: Organization[]) {
+  const detailedOrganizations = organizations.filter(org => org.categories);
+
   cachedOrganizations = cachedOrganizations
-    .filter(({ id }) => !_.find(detailedOrganizations, { id }))
+    .filter(({ id }) => !_.find(organizations, { id }))
     .concat(detailedOrganizations);
 }
 

--- a/src/organizations/index.ts
+++ b/src/organizations/index.ts
@@ -1,5 +1,5 @@
 import async from 'async';
-import axios, { Axios } from 'axios';
+import axios from 'axios';
 import _ from 'lodash';
 import logger from '../logger';
 


### PR DESCRIPTION
Context:
- Sentry caught a 400 error when querying specific organizations from TheGivingBlock API.
- After some investigation, I was able to find that the response from a GET request on `/v1/organizations/list` endpoint, contains organizations that when queried individually return a 400 error, with an error message "Organization not found". I guess that's a consistency error and bad use of REST APIs. 
- The total of organizations retrieved is 1515, on the other hand, the total of detailed organizations is 1377.

This PR solves this issue. Now, instead of throwing an error when receiving a 400, it accepts 400 errors and returns an empty object. Then when updating the cached organizations, it checks if an organization is detailed (only checks if it has a specific detailed field) and removes that organization otherwise.
I assume that it's better to remove the not detailed organizations, instead of retrieving them as well. This way, frontend won't get "confused" and we save some bandwidth in the communications.