### PR TITLE
Remove Jobs on Fail

### DIFF
--- a/src/server/scheduler/index.ts
+++ b/src/server/scheduler/index.ts
@@ -19,6 +19,7 @@ const schedulerQueue = new Queue(SCHEDULER_QUEUE, {
       type: 'exponential',
       delay: 1000,
     },
+    removeOnFail: true,
   },
 });
 

--- a/src/worker/scheduler/index.ts
+++ b/src/worker/scheduler/index.ts
@@ -22,6 +22,7 @@ const schedulerQueue = new Queue(SCHEDULER_QUEUE, {
       type: 'exponential',
       delay: 1000,
     },
+    removeOnFail: true,
   },
 });
 


### PR DESCRIPTION
This PR adds a default option for removing a job when it fails after all attempts.
This is required so we can save some Redis memory.