### PR TITLE
Add Monitoring Filtering

### DIFF
--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -5,6 +5,11 @@ import { RewriteFrames } from '@sentry/integrations';
 const options = {
   attachStacktrace: true,
   dsn: process.env.SENTRY_DSN,
+  beforeSend(event: Sentry.Event) {
+    return event.exception!.values![0].value!.match(/indexing_error:/)
+      ? null
+      : event;
+  },
   environment: process.env.NODE_ENV,
   integrations: [
     new RewriteFrames({


### PR DESCRIPTION
Context:
There are two recurring errors that Sentry monitors that happen every minute due to an indexing error on subgraph. These errors were captured more than 60k times in the last couple of weeks.

This PR adds event filtering to prevent exceeding the monthly quota.