### PR TITLE
Update alreadyRun

### DIFF
--- a/src/jobs/helpers.ts
+++ b/src/jobs/helpers.ts
@@ -25,7 +25,8 @@ async function alreadyRun(name: string, interval: number) {
     where: {
       name,
       createdAt: Raw(
-        (alias) => `DATE_TRUNC('second', ${alias}) > (DATE_TRUNC('second', NOW()) - INTERVAL '${interval} hours')`,
+        (alias) =>
+          `DATE_TRUNC('second', ${alias}) > (DATE_TRUNC('second', NOW()) - INTERVAL '${interval} hours')`,
       ),
     },
     order: {

--- a/src/jobs/helpers.ts
+++ b/src/jobs/helpers.ts
@@ -25,7 +25,7 @@ async function alreadyRun(name: string, interval: number) {
     where: {
       name,
       createdAt: Raw(
-        (alias) => `${alias} >= (NOW() - INTERVAL '${interval} hours')`,
+        (alias) => `DATE_TRUNC('second', ${alias}) > (DATE_TRUNC('second', NOW()) - INTERVAL '${interval} hours')`,
       ),
     },
     order: {


### PR DESCRIPTION
Context:
`collectPerformance` is a job that runs every hour and writes the vault metrics to database. Even though this job was always completed successfully, it only writes to database every two hours, which is not consistent with our logic. It turns out that our function `alreadyRun` checks if a job with a given name already ran in the last hour (in this case) but it takes into account the millisecond part of the timestamp which is kinda tricky and could raise some issues.

This PR solves this issue by truncating the timestamps to seconds in the query that checks if a job already ran in the last hourly interval.