### PR TITLE
Decrease CollectPerformance Job Interval

### DIFF
--- a/src/jobs/collectPerformance.ts
+++ b/src/jobs/collectPerformance.ts
@@ -3,7 +3,7 @@ import { vaultPerformance } from '../contracts/vault';
 import { createJob } from './helpers';
 
 const JOB_NAME = 'collectPerformance';
-const INTERVAL = 1;
+const INTERVAL = 1 / 2;
 
 export default createJob(JOB_NAME, INTERVAL, async function () {
   const repository = await getVaultMetricRepository();

--- a/src/worker/scheduler/index.ts
+++ b/src/worker/scheduler/index.ts
@@ -54,7 +54,7 @@ schedulerQueue.add('updateInvested', null, {
 
 schedulerQueue.add('collectPerformance', null, {
   repeat: {
-    every: 1000 * 60 * 60, // every hour
+    every: 1000 * 60 * 30, // every half-hour
   },
 });
 


### PR DESCRIPTION
Our metrics API has an endpoint `/api/metrics/hour` that returns an hourly performance average. But given that the `collectPerformance` job writes the performance value every 2 hours, we are probably retrieving inconsistent values, or at least we are not retrieving what the endpoint promises. Even though we cannot guarantee that we have a new value every hour, we can enforce that if everything goes as expected, we have a new value every hour.

This PR was originated as a result of the discussion in #31 and it decreases the `collectPerformance` job interval from one hour to half an hour.
