### PR TITLE
Fix Redis Memory leak

### DIFF
--- a/src/server/scheduler/index.ts
+++ b/src/server/scheduler/index.ts
@@ -19,6 +19,7 @@ const schedulerQueue = new Queue(SCHEDULER_QUEUE, {
       type: 'exponential',
       delay: 1000,
     },
+    removeOnComplete: true,
     removeOnFail: true,
   },
 });

--- a/src/worker/scheduler/index.ts
+++ b/src/worker/scheduler/index.ts
@@ -35,6 +35,7 @@ const schedulerQueue = new Queue(SCHEDULER_QUEUE, {
       type: 'exponential',
       delay: 1000,
     },
+    removeOnComplete: true,
     removeOnFail: true,
   },
 });


### PR DESCRIPTION
Our Redis instance stores all jobs and their information, even though we are not using it. As a consequence, we reach the memory limit very quickly.
To avoid this behavior, this PR adds a default option ([removeOnComplete](https://api.docs.bullmq.io/interfaces/BaseJobOptions.html#removeOnComplete)) on a BullMQ Queue, which deletes the job once it is completed. In this case, I used `true` because I think there is no use for the completed jobs, but if we want to keep some jobs, we could specify that number instead of using a boolean.
