### PR TITLE
Fix Bad Queue Instantiation

### DIFF
--- a/src/jobs/helpers.ts
+++ b/src/jobs/helpers.ts
@@ -10,10 +10,10 @@ interface Context {
   logger: Logger;
 }
 
-export function createJob(
+export function createJob<T>(
   name: string,
   interval: number,
-  fn: (ctx: Context, ...args: any) => any,
+  fn: (ctx: Context, args: T) => any,
 ) {
   const context = {
     logger: logger.child({
@@ -21,10 +21,10 @@ export function createJob(
     }),
   };
 
-  return async (data: Data | null, ...args: any) => {
+  return async (data: Data | null, args: T) => {
     if (!data?.force && (await alreadyRun(name, interval))) return;
 
-    const result = await fn(context, ...args);
+    const result = await fn(context, args);
 
     await finishJob(name, context);
 

--- a/src/jobs/reportQueueMetrics.ts
+++ b/src/jobs/reportQueueMetrics.ts
@@ -12,16 +12,14 @@ const INTERVAL = 1 / 12; // every 5 minutes
 export default createJob(
   JOB_NAME,
   INTERVAL,
-  async function (_ctx, queueName: string) {
-    const queue = new Queue(queueName);
-
+  async function (_ctx, queue: Queue) {
     const jobCounts = await queue.getJobCounts('wait', 'completed', 'failed');
 
     const request = {
       body: {
         series: _.map(jobCounts, (count: number, jobType: string) => {
           return {
-            metric: `${queueName}.jobs.${jobType}`,
+            metric: `${queue.name}.jobs.${jobType}`,
             type: 3,
             points: [
               {

--- a/src/metrics/metricsWorker.ts
+++ b/src/metrics/metricsWorker.ts
@@ -13,7 +13,7 @@ export class MetricsWorker extends Worker {
       queue.name,
       async (job: Job) =>
         job.name === 'reportQueueMetrics'
-          ? await reportQueueMetrics(job.data, queue.name)
+          ? await reportQueueMetrics(job.data, queue)
           : await fn(job),
       opts,
       Connection,

--- a/src/server/scheduler/index.ts
+++ b/src/server/scheduler/index.ts
@@ -35,7 +35,7 @@ const schedulerWorker = new MetricsWorker(
   async (job: Job) => {
     switch (job.name) {
       case 'refreshOrganizations':
-        await refreshOrganizations(job.data);
+        await refreshOrganizations(job.data, undefined);
         break;
     }
   },

--- a/src/worker/scheduler/index.ts
+++ b/src/worker/scheduler/index.ts
@@ -10,7 +10,7 @@ import updateInvested from '../../jobs/updateInvested';
 import collectFoundationsPerformance from '../../jobs/collectFoundationsPerformance';
 import mintDonations from '../../jobs/mintDonations';
 
-const JOBS: { [key: string]: Function } = {
+const JOBS: { [key: string]: typeof collectPerformance } = {
   collectPerformance,
   updateInvested,
   collectFoundationsPerformance,
@@ -44,7 +44,7 @@ const schedulerQueue = new Queue(SCHEDULER_QUEUE, {
 const schedulerWorker = new MetricsWorker(
   schedulerQueue,
   async (job: Job) => {
-    if (JOBS[job.name]) await JOBS[job.name](job.data);
+    if (JOBS[job.name]) await JOBS[job.name](job.data, undefined);
     else throw new Error(`Unknown job ${job.name}`);
   },
   {


### PR DESCRIPTION
This PR: 
- fixes a staging error that happens because of a lousy instantiation of a Queue.
[This line](https://github.com/lindy-labs/sc_ethereum-backend/blob/05ce95192797106941cc6225669573ff565989f5/src/jobs/reportQueueMetrics.ts#L16) raises [this bullmq warning](https://github.com/taskforcesh/bullmq/blob/4d5a8e33b614cf099369c18298e5b2963b434b1b/src/classes/queue-base.ts#L44-L52) and then tries to connect to a Redis instance on localhost. In Heroku, there is no local Redis, and because of that, an error arises; I suspect this lousy instantiation has influenced the previous good instantiation of the Queue, and the job execution is chaotic after that.
- Adds a stricter type to `createJob` function instead of accepting `any`

